### PR TITLE
Update cargo-msrv installation to use --locked

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Install cargo-msrv
       shell: bash
-      run: cargo install --locked cargo-msrv@0.18.4
+      run: cargo install cargo-msrv@0.18.4
 
     - name: Setup jq
       uses: dcarbone/install-jq-action@v3.0.1

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Install cargo-msrv
       shell: bash
-      run: cargo install cargo-msrv
+      run: cargo install --locked cargo-msrv@0.18.4
 
     - name: Setup jq
       uses: dcarbone/install-jq-action@v3.0.1


### PR DESCRIPTION
Some of `cargo-msrv`’s dependencies, notably `aws-sdk-s3` and other AWS crates, frequently bump their minimum supported Rust version. As a result, Rust 1.87 cannot install the tool, even though the actual MSRV of this repo is 1.87. We can address this by pinning the dependency versions and using `--locked` so that `cargo install` respects the repository’s original `Cargo.lock`.